### PR TITLE
Rebranded content of .desktop files

### DIFF
--- a/dist/citra-qt.desktop
+++ b/dist/citra-qt.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Citra
+Name=Lime3DS
 GenericName=3DS Emulator
 GenericName[fr]=Émulateur 3DS
 Comment=Nintendo 3DS video game console emulator

--- a/dist/citra-room.desktop
+++ b/dist/citra-room.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Citra Room
-Comment=Multiplayer room host for Citra
+Name=Lime3DS Room
+Comment=Multiplayer room host for Lime3DS
 Icon=citra
 TryExec=citra-room
 Exec=citra-room %f

--- a/dist/citra.desktop
+++ b/dist/citra.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=Citra
+Name=Lime3DS
 GenericName=3DS Emulator
 GenericName[fr]=Émulateur 3DS
 Comment=Nintendo 3DS video game console emulator


### PR DESCRIPTION
Updates the content of all Linux .desktop files from to reference Lime3DS instead of Citra.

Notably, this doesn't change any filenames, only the names displayed in the application menu.